### PR TITLE
Minor fix: Replaced UTF-8 double quotes (”) with ASCII double quote

### DIFF
--- a/debian7/root/etc/hhvm/server.hdf
+++ b/debian7/root/etc/hhvm/server.hdf
@@ -16,7 +16,7 @@ Log {
   Access {
     * {
       File = /var/log/hhvm/access.log
-      Format = %h %l %u % t \”%r\” %>s %b
+      Format = %h %l %u % t \"%r\" %>s %b
     }
   }
 }

--- a/fedora20/root/etc/hhvm/server.hdf
+++ b/fedora20/root/etc/hhvm/server.hdf
@@ -16,7 +16,7 @@ Log {
   Access {
     * {
       File = /var/log/hhvm/access.log
-      Format = %h %l %u % t \”%r\” %>s %b
+      Format = %h %l %u % t \"%r\" %>s %b
     }
   }
 }

--- a/ubuntu12.04/root/etc/hhvm/server.hdf
+++ b/ubuntu12.04/root/etc/hhvm/server.hdf
@@ -16,7 +16,7 @@ Log {
   Access {
     * {
       File = /var/log/hhvm/access.log
-      Format = %h %l %u % t \”%r\” %>s %b
+      Format = %h %l %u % t \"%r\" %>s %b
     }
   }
 }

--- a/ubuntu13.10/root/etc/hhvm/server.hdf
+++ b/ubuntu13.10/root/etc/hhvm/server.hdf
@@ -16,7 +16,7 @@ Log {
   Access {
     * {
       File = /var/log/hhvm/access.log
-      Format = %h %l %u % t \”%r\” %>s %b
+      Format = %h %l %u % t \"%r\" %>s %b
     }
   }
 }


### PR DESCRIPTION
The server.hdf was containing a 'RIGHT DOUBLE QUOTATION MARK'.

Replaced non ASCII char with ASCII char. 
