### PR TITLE
Fix in FastCGI package: /var/run is a tmpfs in Ubuntu 12.04 and Fedora

### DIFF
--- a/hhvm-fastcgi/skeleton/etc/init.d/hhvm-fastcgi
+++ b/hhvm-fastcgi/skeleton/etc/init.d/hhvm-fastcgi
@@ -54,6 +54,16 @@ ${ADDITIONAL_ARGS}"
 #
 # Function that starts the daemon/service
 #
+check_run_dir() {
+    # Only perform folder creation, if the PIDFILE location was not modified
+    PIDFILE_BASEDIR=$(dirname ${PIDFILE})
+    # We might have a tmpfs /var/run.
+    if [ "/var/run/hhvm" = "${PIDFILE_BASEDIR}" ] && [ ! -d /var/run/hhvm ]; then
+        mkdir -p -m0755 /var/run/hhvm
+        chown $RUN_AS_USER:$RUN_AS_USER /var/run/hhvm
+    fi
+}
+
 do_start()
 {
         # Return
@@ -112,6 +122,7 @@ do_reload() {
 
 case "$1" in
   start)
+        check_run_dir
         [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
         do_start
         case "$?" in
@@ -144,6 +155,7 @@ case "$1" in
         # If the "reload" option is implemented then remove the
         # 'force-reload' alias
         #
+        check_run_dir
         log_daemon_msg "Restarting $DESC" "$NAME"
         do_stop
         case "$?" in


### PR DESCRIPTION
The default location of the hhvm-fastcgi PID file is: /var/run/hhvm/hhvm-fastcgi.pid
The hhvm FastCGI daemon is normaly started as a non privileged user like 'www-data.
Due to Linux file permissions the hhvm daemon needs to have write access to
the basedir /var/run/hhvm.
In recent version of Ubuntu and Fedora, the /var/run folder is mounted as 'tmpfs'
device. /var/run folder is created from scratch on every boot. This leads to the
problem that the non privileged user is not able to create the PID file under
/var/run/hhvm/ which was not created during to boot up process.

To fix this issue create the folder on daemon start up.

More information about (/var)/run and tmpfs:
https://wiki.debian.org/ReleaseGoals/RunDirectory#Stage_.232:_After_system_reboot
http://fedoraproject.org/wiki/Features/var-run-tmpfs

Note:
In the future /var/run will be replaced by /run:
http://askubuntu.com/a/57302
http://lwn.net/Articles/436012/
