### PR TITLE
Keep nightly versions semver-compliant

### DIFF
--- a/hhvm/deb/package
+++ b/hhvm/deb/package
@@ -17,7 +17,7 @@ VERSION=$3
 SRC=$4
 SKELETON=$DIR/skeleton
 PACKAGE=$5
-NIGHTLY_DATE=`date +%Y-%m-%d`
+NIGHTLY_DATE=`date +%Y.%m.%d`
 
 if [ ! -d $DISTRO_DIR ]; then
 	echo "directory $DISTRO_DIR doesn't exist"
@@ -83,8 +83,8 @@ fi
 
 if [ "$VERSION" = "nightly" ]; then
 	git checkout master
-	perl -pi -e 's/[0-9.]*-dev/nightly-'$NIGHTLY_DATE/ hphp/version
-	perl -pi -e 's/[0-9.]*-dev/nightly-'$NIGHTLY_DATE/ hphp/system/idl/constants.idl.json
+	perl -pi -e 's/([0-9.]*-dev)/\1+'$NIGHTLY_DATE/ hphp/version
+	perl -pi -e 's/([0-9.]*-dev)/\1+'$NIGHTLY_DATE/ hphp/system/idl/constants.idl.json
 else
 	git checkout HHVM-$VERSION
 	if ! grep -q $VERSION hphp/version; then


### PR DESCRIPTION
It appends the nightly date as build metadata (e.g. `+2014.01.11`) as per the semver spec instead of modifying it. The only other place NIGHTLY_DATE is used is in the package Version, I hope it doesn't trip anything up to have dots instead of dashes in there. Otherwise to be safe we could have two different formats.
