### PR TITLE
Mark user-adjustable config files in conffiles

### DIFF
--- a/hhvm/deb/skeleton/DEBIAN/conffiles
+++ b/hhvm/deb/skeleton/DEBIAN/conffiles
@@ -1,0 +1,3 @@
+/etc/hhvm/config.hdf
+/etc/hhvm/server.hdf
+/etc/hhvm/php.ini


### PR DESCRIPTION
Installing new versions of hhvm via deb would overwrite any changes
users have made to their configuration files.  Add the files we
expect users may change to the conffiles list of distributed packges
so dpkg asks before overwriting these files.
