### PR TITLE
Provide HHVM as a low-priority alternative to php

### DIFF
--- a/hhvm/deb/skeleton/DEBIAN/postinst
+++ b/hhvm/deb/skeleton/DEBIAN/postinst
@@ -1,7 +1,10 @@
 #!/bin/sh 
-# hphp.postinst, runs ldconfig 
+# hphp.postinst, runs ldconfig, adds php alternative
 set -e 
 
 if [ "$1" = "configure" ]; then
   ldconfig
 fi
+
+# php5-cli uses a priority of 50, so we pick a much smaller number
+/usr/sbin/update-alternatives --install /usr/bin/php php /usr/bin/hhvm 10

--- a/hhvm/deb/skeleton/DEBIAN/postrm
+++ b/hhvm/deb/skeleton/DEBIAN/postrm
@@ -1,7 +1,9 @@
 #!/bin/sh 
-# hphp.postrm, runs ldconfig 
+# hphp.postrm, runs ldconfig, removes alternative
 set -e 
 
 if [ "$1" = "remove" ]; then
   ldconfig
 fi
+
+/usr/sbin/update-alternatives --remove php /usr/bin/hhvm


### PR DESCRIPTION
This lets the alternative system add a symlink from /usr/bin/php to /usr/bin/hhvm if one with a higher priority doesn't exist. Having php5-cli installed, or installing it, will cause the system to change the symlink to point to the php5 binary instead.
