### PR TITLE
Minor glitch fix in ProxyPassMatch regex match

### DIFF
--- a/hhvm/deb/skeleton/etc/apache2/mods-available/hhvm_proxy_fcgi.conf
+++ b/hhvm/deb/skeleton/etc/apache2/mods-available/hhvm_proxy_fcgi.conf
@@ -1,1 +1,1 @@
-ProxyPassMatch ^/(.*\.(hh|php)(/.*)?)$ fcgi://127.0.0.1:9000/var/www/$1
+ProxyPassMatch ^/(.+\.(hh|php)(/.*)?)$ fcgi://127.0.0.1:9000/var/www/$1


### PR DESCRIPTION
This fixes a minor glitch in the ProxyPassMatch regex match.

The old regex also matches something like '/.php' or '/.hh'. Commented in #26
