### PR TITLE
/etc/init.d/hhvm status returning incorrect error code

### DIFF
--- a/hhvm/deb/skeleton/etc/init.d/hhvm
+++ b/hhvm/deb/skeleton/etc/init.d/hhvm
@@ -140,7 +140,7 @@ case "$1" in
         esac
         ;;
   status)
-        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
         ;;
   #reload|force-reload)
         #


### PR DESCRIPTION
`/etc/init.d/hhvm status` is always returning incorrect error code:

```
$ /etc/init.d/hhvm status; echo $?
[FAIL] hhvm is not running ... failed!
1
```
