### PR TITLE
Added a dev only mode to the packaging script

### DIFF
--- a/hhvm/deb/package
+++ b/hhvm/deb/package
@@ -248,7 +248,7 @@ if [ "$NIGHTLY" = true ]; then
         fi
     else
         if [ "$DEBUG" = false ]; then
-            rm $nPACKAGE/staging/pool/main/h/hhvm-${VERSION}/*dev*${RELEASE}*.deb || true
+            rm $PACKAGE/staging/pool/main/h/hhvm-${VERSION}/*dev*${RELEASE}*.deb || true
         fi
     fi
 fi


### PR DESCRIPTION
The dev only mode will check if the version has a -dev in it and will build a dev only version of the package.
