### PR TITLE
Added a dev only mode to the packaging script take2

### DIFF
--- a/hhvm/deb/package
+++ b/hhvm/deb/package
@@ -41,7 +41,7 @@ if [ `echo $VERSION | grep '^nightly.*'` ]; then
     NIGHTLY=true
     echo "Nightly"
 fi
-if [ `echo $VERSION | grep '.*-dev$'` ]; then
+if [ `echo $VERSION | grep '.*-dev*'` ]; then
     DEVONLY=true
     VERSION=`echo $VERSION | cut -d '-' -f 1`
     echo "Dev only, Debug off"


### PR DESCRIPTION
This version will still build the regular package. It will not upload the regular package to the server however.
