### PR TITLE
Fix build for cmake 2.8.7

### DIFF
--- a/hhvm/deb/package
+++ b/hhvm/deb/package
@@ -212,10 +212,18 @@ if [ "$DEBUG" = false ]; then
         cp -r $SKELETON-dev/* $DPACKAGE/root/
         cp -r $DISTRO_DIR-dev/* $DPACKAGE/root/
         cp -r $BUILD/usr/include/hphp $DPACKAGE/root/usr/include/
-        # this should give us the lib/<architecture> of the machine we are on
-        ARCH=`dpkg-architecture -qDEB_BUILD_GNU_TYPE`
-        mkdir --parents $BUILD/usr/lib/$ARCH
-        cp -r $BUILD/usr/lib/$ARCH/hhvm $DPACKAGE/root/usr/lib/$ARCH/
+        # cmake 2.8.7 does not support debian multiarch
+        if cmake --version | grep --quiet "2\.8\.7"; then
+            echo "cmake is version 2.8.7. building lib files into lib"
+            mkdir --parents $BUILD/usr/lib
+            cp -r $BUILD/usr/lib/hhvm $DPACKAGE/root/usr/lib/
+        else
+            # this should give us the lib/<architecture> of the machine we are on
+            ARCH=`dpkg-architecture -qDEB_BUILD_GNU_TYPE`
+            echo "cmake is not 2.8.7. building lib files into lib/$ARCH"
+            mkdir --parents $BUILD/usr/lib/$ARCH
+            cp -r $BUILD/usr/lib/$ARCH/hhvm $DPACKAGE/root/usr/lib/$ARCH/
+        fi
         cp -r $BUILD/usr/bin/hphpize $DPACKAGE/root/usr/bin/
         chmod 755 $DPACKAGE/root/usr/bin/hphpize
         if [ "$NIGHTLY" = true ]; then


### PR DESCRIPTION
I guess cmake 2.8.7 does not implement debian multiarching; I was reading the documentation for 2.8.8 :/. We can either bump the cmake version on the packaging machines or use this change. 
