### PR TITLE
for some reason the hhvm directory was being flattened this should fix it

### DIFF
--- a/hhvm/deb/package
+++ b/hhvm/deb/package
@@ -216,13 +216,13 @@ if [ "$DEBUG" = false ]; then
         if cmake --version | grep --quiet "2\.8\.7"; then
             echo "cmake is version 2.8.7. building lib files into lib"
             mkdir --parents $BUILD/usr/lib
-            cp -r $BUILD/usr/lib/hhvm $DPACKAGE/root/usr/lib/
+            cp -r $BUILD/usr/lib/hhvm $DPACKAGE/root/usr/lib/hhvm
         else
             # this should give us the lib/<architecture> of the machine we are on
             ARCH=`dpkg-architecture -qDEB_BUILD_GNU_TYPE`
             echo "cmake is not 2.8.7. building lib files into lib/$ARCH"
             mkdir --parents $BUILD/usr/lib/$ARCH
-            cp -r $BUILD/usr/lib/$ARCH/hhvm $DPACKAGE/root/usr/lib/$ARCH/
+            cp -r $BUILD/usr/lib/$ARCH/hhvm $DPACKAGE/root/usr/lib/$ARCH/hhvm
         fi
         cp -r $BUILD/usr/bin/hphpize $DPACKAGE/root/usr/bin/
         chmod 755 $DPACKAGE/root/usr/bin/hphpize


### PR DESCRIPTION
I was unable to reproduce what was going on in the nightlies and my understanding is a trailing / should be sufficient to copy the directory. This should hopefully work however. 
