### PR TITLE
Updated defaults to match Debian's PHP

### DIFF
--- a/hhvm/deb/skeleton/etc/hhvm/php.ini
+++ b/hhvm/deb/skeleton/etc/hhvm/php.ini
@@ -1,4 +1,7 @@
 ; php options
+session.save_handler = files
+session.save_path = /var/lib/php5
+session.gc_maxlifetime = 1440
 
 ; hhvm specific 
 hhvm.log.level = Warning


### PR DESCRIPTION
The session.save_handler and session.gc_maxlifetime are already correct from the defaults, but I'm explicitly setting them here so the garbage collection is more likely to keep working.  Using session.save_path=/var/lib/php5 is recommended since it is not world-readable, already owned by www-data, and is the default for other PHP SAPIs.
