### PR TITLE
Start HHVM after installation

### DIFF
--- a/hhvm/deb/skeleton/DEBIAN/postinst
+++ b/hhvm/deb/skeleton/DEBIAN/postinst
@@ -30,3 +30,7 @@ echo "* "
 echo "* You can use HHVM for /usr/bin/php even if you have php-cli installed:"
 echo "* $ sudo /usr/bin/update-alternatives --install /usr/bin/php php /usr/bin/hhvm 60"
 echo "********************************************************************"
+
+if which invoke-rc.d >/dev/null 2>&1; then
+    invoke-rc.d hhvm start
+fi


### PR DESCRIPTION
According to the [Debian Policy Manual](https://www.debian.org/doc/debian-policy/ch-opersys.html) this is the way to start a service after installation.

This starts HHVM not matter if it was started before the upgrade and it starts HHVM after the first installation. I don't know if this is the best approach but it seemed reasonable to me.

Fixes #103