### PR TITLE
Add LICENSE, PATENTS and CONTRIBUTING.md files.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to HHVM packaging
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Our Development Process
+
+All development is on github; there are no Facebook-specific changes or code review
+practices.
+
+## Pull Requests
+We actively welcome your pull requests.
+1. Fork the repo and create your branch from `master`. 
+2. If you've added code that should be tested, add tests
+3. If you've changed APIs, update the documentation. 
+4. Ensure the test suite passes. 
+5. Make sure your code lints. 
+6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Contributor License Agreement ("CLA")
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Facebook's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues  
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+disclosure of security bugs. In those cases, please go through the process
+outlined on that page and do not file a public issue.
+
+## License
+By contributing to HHVM packaging you agree that your contributions will be
+licensed under its BSD license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Please note that this repository includes archives of the software being
-benchmarked, which is licensed separately, under different terms; see the
-notices inside the archives for details.
+Please note that this repository includes archives of compiled versions
+of some of the software being packaged. The source and object code for
+that software is licensed separately, under different terms.
 
 ------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,36 @@
+Please note that this repository includes archives of the software being
+benchmarked, which is licensed separately, under different terms; see the
+notices inside the archives for details.
+
+------
+
+BSD License
+
+For HHVM packaging software
+
+Copyright (c) 2015, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/PATENTS
+++ b/PATENTS
@@ -1,0 +1,23 @@
+Additional Grant of Patent Rights
+
+"Software" means the HHVM packaging software distributed by Facebook, Inc.
+
+Facebook hereby grants you a perpetual, worldwide, royalty-free, non-exclusive,
+irrevocable (subject to the termination provision below) license under any
+rights in any patent claims owned by Facebook, to make, have made, use, sell,
+offer to sell, import, and otherwise transfer the Software. For avoidance of
+doubt, no license is granted under Facebook’s rights in any patent claims that
+are infringed by (i) modifications to the Software made by you or a third party,
+or (ii) the Software in combination with any software or other technology
+provided by you or a third party.
+
+The license granted hereunder will terminate, automatically and without notice,
+for anyone that makes any claim (including by filing any lawsuit, assertion or
+other action) alleging (a) direct, indirect, or contributory infringement or
+inducement to infringe any patent: (i) by Facebook or any of its subsidiaries or
+affiliates, whether or not such claim is related to the Software, (ii) by any
+party if such claim arises in whole or in part from any software, product or
+service of Facebook or any of its subsidiaries or affiliates, whether or not
+such claim is related to the Software, or (iii) by any party relating to the
+Software; or (b) that any right in any patent claim of Facebook is invalid or
+unenforceable.


### PR DESCRIPTION
The text is copied directly from oss-performance, with substitutions
to use the term "HHVM packaging".

This addresses https://github.com/hhvm/packaging/issues/106

This is a little creepy.  My developer license agreement lets me make
contributions, but I'm in here creating legal boilerplate describing
how I can make contributions.