### PR TITLE
Save session to new directory /var/lib/hhvm

### DIFF
--- a/hhvm/deb/skeleton/DEBIAN/postinst
+++ b/hhvm/deb/skeleton/DEBIAN/postinst
@@ -39,6 +39,7 @@ echo "*    --install /usr/bin/php php /usr/bin/hhvm 60"
 echo "********************************************************************"
 
 install -d -m 755 -o www-data -g www-data /var/run/hhvm
+install -d -m 01733 /var/lib/hhvm/sessions
 
 if which invoke-rc.d >/dev/null 2>&1; then
     invoke-rc.d hhvm start

--- a/hhvm/deb/skeleton/etc/hhvm/php.ini
+++ b/hhvm/deb/skeleton/etc/hhvm/php.ini
@@ -1,6 +1,6 @@
 ; php options
 session.save_handler = files
-session.save_path = /var/lib/php5
+session.save_path = /var/lib/hhvm/sessions
 session.gc_maxlifetime = 1440
 
 ; hhvm specific 


### PR DESCRIPTION
/var/lib/php5 might not exists on every system and doesn't seem to be
a very good place to store HHVM's session data either way.

This change creates a new directory /var/lib/hhvm with the same permissions
as the old /var/lib/php5. It also updates the default php.ini to store the
session data there.
Resolves #101
Resolves #81