### PR TITLE
use invoke-rc.d to stop hhvm

### DIFF
--- a/hhvm/deb/skeleton/DEBIAN/preinst
+++ b/hhvm/deb/skeleton/DEBIAN/preinst
@@ -2,7 +2,6 @@
 
 set -e
 
-if [ -f /etc/init.d/hhvm ]
-then
-	/etc/init.d/hhvm stop
+if which invoke-rc.d >/dev/null 2>&1; then
+    invoke-rc.d hhvm stop
 fi


### PR DESCRIPTION
This will stop upstart hhvm if used, otherwise it will do /etc/init.d/hhvm stop

This mirrors postinst
