### PR TITLE
Use /var/cache/hhvm for default hhvm.repo.central.path

### DIFF
--- a/hhvm/deb/package
+++ b/hhvm/deb/package
@@ -237,6 +237,7 @@ if [ ! -d $PACKAGE/root ]; then
     fi
     fakeroot -s $FAKEROOT chown -R root:root $PACKAGE/root
     fakeroot -s $FAKEROOT -i $FAKEROOT chown -R www-data:www-data $PACKAGE/root/var/log/hhvm/
+    fakeroot -s $FAKEROOT -i $FAKEROOT chown -R www-data:www-data $PACKAGE/root/var/cache/hhvm/
     echo "finished creating hhvm package contents"
 fi
 

--- a/hhvm/deb/skeleton/etc/hhvm/server.ini
+++ b/hhvm/deb/skeleton/etc/hhvm/server.ini
@@ -9,4 +9,4 @@ hhvm.server.type = fastcgi
 hhvm.server.default_document = index.php
 hhvm.log.use_log_file = true
 hhvm.log.file = /var/log/hhvm/error.log
-hhvm.repo.central.path = /var/run/hhvm/hhvm.hhbc
+hhvm.repo.central.path = /var/cache/hhvm/hhvm.hhbc


### PR DESCRIPTION
The /var/run directory may be a relatively small tmpfs. The hhvm.hhcm file can
easily grow to fill this filesystem.
