### PR TITLE
Use the default user/group if provided

### DIFF
--- a/hhvm/deb/skeleton/DEBIAN/postinst
+++ b/hhvm/deb/skeleton/DEBIAN/postinst
@@ -38,7 +38,14 @@ echo "*    --install /usr/bin/php php /usr/bin/hhvm 60"
 
 echo "********************************************************************"
 
-install -d -m 755 -o www-data -g www-data /var/run/hhvm
+RUN_AS_USER="www-data"
+RUN_AS_GROUP="www-data"
+
+if [ -f /etc/default/hhvm ]; then
+    . /etc/default/hhvm
+fi
+
+install -d -m 755 -o $RUN_AS_USER -g $RUN_AS_GROUP /var/run/hhvm
 install -d -m 01733 /var/lib/hhvm/sessions
 
 if which invoke-rc.d >/dev/null 2>&1; then


### PR DESCRIPTION
Rather than always using www-data:www-data, use the values provided in /etc/default/hhvm if they've been specified.

Fixes facebook/hhvm#6383