### PR TITLE
switch to GCC 5.5.0 with gcc4-compatible ABI.

### DIFF
--- a/build-deps/build-gcc
+++ b/build-deps/build-gcc
@@ -9,7 +9,7 @@
 
 set -ex 
 
-VERSION=4.9.4
+VERSION=5.5.0
 
 cd /tmp
 wget -q http://mirrors.ocf.berkeley.edu/gnu/gcc/gcc-$VERSION/gcc-$VERSION.tar.gz
@@ -35,7 +35,9 @@ unset CXXFLAGS_FOR_TARGET
 $(pwd)/../gcc-$VERSION/configure \
   --prefix=/opt/hhvm-build-deps \
   --enable-languages=c,c++ \
-  --disable-multilib
+  --disable-multilib \
+  --with-default-libstdcxx-abi=gcc4-compatible \
+  --disable-libstdcxx-dual-abi
 make -j8
 make install
 cd /tmp


### PR DESCRIPTION
GCC 4.9 seems to be having a bug leading to a regression into HHVM. See:

https://github.com/facebook/hhvm/issues/8011

Signed-off-by: Arthur Loiret <arthur.loiret@adeline.mobi>