### PR TITLE
When adding a new version to repos, only download that version

### DIFF
--- a/aws/bin/update-repos
+++ b/aws/bin/update-repos
@@ -32,7 +32,8 @@ mkdir /mnt/dl.hhvm.com
 mount /dev/xvdf /mnt/dl.hhvm.com
 
 aws s3 sync s3://hhvm-downloads/ /mnt/dl.hhvm.com/ --exclude '*nightly*' --exclude "source/nightlies/*" --exclude "homebrew-bottles/*"
-aws s3 sync s3://hhvm-scratch/ /var/hhvm-scratch/
+mkdir -p "/var/hhvm-scratch/${VERSION}"
+aws s3 sync "s3://hhvm-scratch/${VERSION}" "/var/hhvm-scratch/${VERSION}"
 
 export PACKAGING_BRANCH
 /opt/hhvm-packaging/aws/bin/create-apt-repos


### PR DESCRIPTION
When updating many releases, we got timeouts due to this.

refs #175

Test Plan: ship this today, check the nightlies tomorrow