### PR TITLE
remove artful from 3.30 targets

### DIFF
--- a/CURRENT_TARGETS
+++ b/CURRENT_TARGETS
@@ -2,6 +2,5 @@ debian-8-jessie
 debian-9-stretch
 ubuntu-14.04-trusty
 ubuntu-16.04-xenial
-ubuntu-17.10-artful
 ubuntu-18.04-bionic
 ubuntu-18.10-cosmic


### PR DESCRIPTION
This always fails in `apt-get update` because artful is unsupported and its repositories no longer exist.

Since it's been that way for the last few versions and no one has complained, I guess we can just remove it from the list?