### PR TITLE
Fix build-status for source tarballs

### DIFF
--- a/aws/lambdas/hhvm-get-build-status/index.js
+++ b/aws/lambdas/hhvm-get-build-status/index.js
@@ -29,21 +29,22 @@ async function get_distros(branch) {
 exports.handler = async (event) => {
   const {nightly, version, branch} = get_version_info(event);
 
-  const prefix = nightly
+  const bin_prefix = nightly
     ? 'hhvm-nightly-'+version
     : 'hhvm-'+(version.split('.').slice(0, 2).join('.'))+'-'+version;
+  const src_prefix = nightly ? bin_prefix : ('hhvm-'+version);
   const paths = {
     'macos-high_sierra':
-      'homebrew-bottles/'+prefix+'.high_sierra.bottle.tar.gz',
+      'homebrew-bottles/'+bin_prefix+'.high_sierra.bottle.tar.gz',
     'macos-mojave':
-      'homebrew-bottles/'+prefix+'.mojave.bottle.tar.gz',
+      'homebrew-bottles/'+bin_prefix+'.mojave.bottle.tar.gz',
   };
   if (nightly) {
-    paths.source = 'source/nightlies/'+prefix+'.tar.gz';
-    paths.source_gpg = 'source/nightlies/'+prefix+'.tar.gz.sig';
+    paths.source = 'source/nightlies/'+src_prefix+'.tar.gz';
+    paths.source_gpg = 'source/nightlies/'+src_prefix+'.tar.gz.sig';
   } else {
-    paths.source = 'source/'+prefix+'.tar.gz';
-    paths.source_gpg = 'source/'+prefix+'.tar.gz.sig';
+    paths.source = 'source/'+src_prefix+'.tar.gz';
+    paths.source_gpg = 'source/'+src_prefix+'.tar.gz.sig';
   }
 
   const distros = await get_distros(branch);


### PR DESCRIPTION
Before:

```
$ curl https://hhvm.com/api/build-status/4.18.1 | jq
{
  "success": false,
  "version": "4.18.1",
  "succeeded": [
    "macos-high_sierra",
    "macos-mojave",
    "debian-8-jessie",
    "debian-9-stretch",
    "ubuntu-14.04-trusty",
    "ubuntu-16.04-xenial",
    "ubuntu-18.04-bionic",
    "ubuntu-18.10-cosmic",
    "ubuntu-19.04-disco"
  ],
  "failed": {
    "source": "https://dl.hhvm.com/source/hhvm-4.18-4.18.1.tar.gz",
    "source_gpg": "https://dl.hhvm.com/source/hhvm-4.18-4.18.1.tar.gz.sig"
  }
}
```

After:

```
$ curl https://hhvm.com/api/build-status/2019.08.15 | jq
{
  "success": true,
  "version": "2019.08.15",
  "succeeded": [
    "macos-high_sierra",
    "macos-mojave",
    "source",
    "source_gpg",
    "debian-8-jessie",
    "debian-9-stretch",
    "ubuntu-14.04-trusty",
    "ubuntu-16.04-xenial",
    "ubuntu-18.04-bionic",
    "ubuntu-18.10-cosmic",
    "ubuntu-19.04-disco"
  ],
  "failed": {}
}
$ curl https://hhvm.com/api/build-status/4.18.1 | jq
{
  "success": true,
  "version": "4.18.1",
  "succeeded": [
    "macos-high_sierra",
    "macos-mojave",
    "source",
    "source_gpg",
    "debian-8-jessie",
    "debian-9-stretch",
    "ubuntu-14.04-trusty",
    "ubuntu-16.04-xenial",
    "ubuntu-18.04-bionic",
    "ubuntu-18.10-cosmic",
    "ubuntu-19.04-disco"
  ],
  "failed": {}
}
```