### PR TITLE
Stop creating docker images for succesful builds

### DIFF
--- a/aws/userdata/make-binary-package.sh
+++ b/aws/userdata/make-binary-package.sh
@@ -53,32 +53,23 @@ export VERSION
 export IS_NIGHTLY
 
 aws s3 sync "s3://hhvm-nodist/${DISTRO}/" nodist/
-if bin/make-package-in-throwaway-container "$DISTRO"; then
-  IMAGE_NAME=hhvm-succeeded-builds
-  FAILED=false
-else
+if ! bin/make-package-in-throwaway-container "$DISTRO"; then
   IMAGE_NAME=hhvm-failed-builds
-  FAILED=true
-fi
-# On modern systems, this should just be:
-#   $(aws ecr get-login --no-include-email --region us-west-2)
-# This is slightly different to support the older versions of the AWS and
-# docker CLIs in our base image (currently Ubuntu 16.04)
-$(aws ecr get-login --region us-west-2 | sed 's/ -e none / /')
+  # On modern systems, this should just be:
+  #   $(aws ecr get-login --no-include-email --region us-west-2)
+  # This is slightly different to support the older versions of the AWS and
+  # docker CLIs in our base image (currently Ubuntu 16.04)
+  $(aws ecr get-login --region us-west-2 | sed 's/ -e none / /')
 
-CONTAINER_ID="$(docker ps -aq)"
-EC2_INSTANCE_ID="$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)"
+  CONTAINER_ID="$(docker ps -aq)"
+  EC2_INSTANCE_ID="$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)"
 
-# Create a Docker image from the container (instance)
-DOCKER_REPOSITORY="223121549624.dkr.ecr.us-west-2.amazonaws.com"
-IMAGE_NAME="${DOCKER_REPOSITORY}/${IMAGE_NAME}:${VERSION}_${DISTRO}_${EC2_INSTANCE_ID}"
-docker commit "${CONTAINER_ID}" "${IMAGE_NAME}"
-# Push to ECR so we can download later
-docker push "${IMAGE_NAME}"
-
-if $FAILED; then
-  # Don't upload anything to S3 for this distro, or the repo update
-  # worker gets confused
+  # Create a Docker image from the container (instance)
+  DOCKER_REPOSITORY="223121549624.dkr.ecr.us-west-2.amazonaws.com"
+  IMAGE_NAME="${DOCKER_REPOSITORY}/${IMAGE_NAME}:${VERSION}_${DISTRO}_${EC2_INSTANCE_ID}"
+  docker commit "${CONTAINER_ID}" "${IMAGE_NAME}"
+  # Push to ECR so we can download later
+  docker push "${IMAGE_NAME}"
   shutdown -h now
   exit 1
 fi


### PR DESCRIPTION
While I'm here, also stop keeping the workers alive for 3 hours after
a failed build. Logs seem to work well.

closes #199