### PR TITLE
Enable debian-10-buster support

### DIFF
--- a/CURRENT_TARGETS
+++ b/CURRENT_TARGETS
@@ -1,5 +1,6 @@
 debian-8-jessie
 debian-9-stretch
+debian-10-buster
 ubuntu-16.04-xenial
 ubuntu-18.04-bionic
 ubuntu-18.10-cosmic


### PR DESCRIPTION
Test Plan:

Manual build in progress; will not land if fails, or if the repo update
fails.

Build log ID is
`2019/09/20/hhvm-2019.09.20_debian-10-buster_i-053434a6d708c0830`