### PR TITLE
Make create-apt-repos build for repos not in CURRENT_TARGETS

### DIFF
--- a/aws/bin/create-apt-repos
+++ b/aws/bin/create-apt-repos
@@ -33,7 +33,10 @@ cd /opt/hhvm-packaging
 git checkout "$PACKAGING_BRANCH"
 RESYNC=false
 
-for DISTRO in $(<CURRENT_TARGETS); do
+for DISTRO in *; do
+  if [ ! -e ${DISTRO}/DISTRIBUTION ]; then
+    continue
+  fi
   ROOT_REPO="$(echo "$DISTRO" | cut -f1 -d-)" # eg 'debian' or 'ubuntu'
   DISTRO="$(<$DISTRO/DISTRIBUTION)"
   for REPO in $(<DEBIAN_REPOSITORIES); do


### PR DESCRIPTION
Useful for new distributions - do a test build before adding to
CURRENT_TARGETS.

Test plan:

buster build failed. Applied, then:

```
$ PACKAGING_BRANCH=master aws/bin/create-apt-repos
M	aws/bin/create-apt-repos
Already on 'master'
Your branch is up-to-date with 'origin/master'.
Looking for repo "buster" in "debian"...
... creating.
Exporting buster...
copy: s3://hhvm-nodist/empty to s3://hhvm-downloads/debian/dists/buster/main/binary-i386/Packages
copy: s3://hhvm-nodist/empty to s3://hhvm-downloads/debian/dists/buster/main/binary-amd64/Packages
Looking for repo "jessie" in "debian"...
... exists.
Looking for repo "stretch" in "debian"...
... exists.
Looking for repo "xenial" in "ubuntu"...
... exists.
Looking for repo "bionic" in "ubuntu"...
... exists.
Looking for repo "cosmic" in "ubuntu"...
... exists.
Looking for repo "disco" in "ubuntu"...
... exists.
upload: ../mnt/dl.hhvm.com/debian/db/version to s3://hhvm-downloads/debian/db/version
upload: ../mnt/dl.hhvm.com/debian/conf/distributions to s3://hhvm-downloads/debian/conf/distributions
upload: ../mnt/dl.hhvm.com/debian/db/release.caches.db to s3://hhvm-downloads/debian/db/release.caches.db
upload: ../mnt/dl.hhvm.com/debian/dists/buster/InRelease to s3://hhvm-downloads/debian/dists/buster/InRelease
upload: ../mnt/dl.hhvm.com/debian/db/packages.db to s3://hhvm-downloads/debian/db/packages.db
upload: ../mnt/dl.hhvm.com/debian/dists/buster/main/source/Sources.gz to s3://hhvm-downloads/debian/dists/buster/main/source/Sources.gz
upload: ../mnt/dl.hhvm.com/debian/dists/buster/main/binary-i386/Packages.gz to s3://hhvm-downloads/debian/dists/buster/main/binary-i386/Packages.gz
upload: ../mnt/dl.hhvm.com/debian/dists/buster/Release.gpg to s3://hhvm-downloads/debian/dists/buster/Release.gpg
upload: ../mnt/dl.hhvm.com/debian/dists/buster/main/binary-amd64/Packages.gz to s3://hhvm-downloads/debian/dists/buster/main/binary-amd64/Packages.gz
upload: ../mnt/dl.hhvm.com/debian/dists/buster/Release to s3://hhvm-downloads/debian/dists/buster/Release
upload: ../mnt/dl.hhvm.com/debian/dists/buster/main/source/Release to s3://hhvm-downloads/debian/dists/buster/main/source/Release
upload: ../mnt/dl.hhvm.com/debian/dists/buster/main/binary-amd64/Release to s3://hhvm-downloads/debian/dists/buster/main/binary-amd64/Release
upload: ../mnt/dl.hhvm.com/debian/dists/buster/main/binary-i386/Release to s3://hhvm-downloads/debian/dists/buster/main/binary-i386/Release
upload: ../mnt/dl.hhvm.com/debian/pool/main/h/hhvm-nightly/index.html to s3://hhvm-downloads/debian/pool/main/h/hhvm-nightly/index.html
upload: ../mnt/dl.hhvm.com/source/nightlies/index.html to s3://hhvm-downloads/source/nightlies/index.html
upload: ../mnt/dl.hhvm.com/ubuntu/pool/main/h/hhvm-nightly/index.html to s3://hhvm-downloads/ubuntu/pool/main/h/hhvm-nightly/index.html

$
```