### PR TITLE
trigger MacOS builds from AWS

### DIFF
--- a/aws/hhvm1/lambdas/check_if_repos_changed.py
+++ b/aws/hhvm1/lambdas/check_if_repos_changed.py
@@ -16,6 +16,7 @@ def lambda_handler(event, context=None):
     if (
       'success' in vr.get('PublishBinaryPackages', {}) or
       'success' in vr.get('PublishSourceTarball', {}) or
+      'success' in vr.get('BuildAndPublishMacOS', {}) or
       # nightlies are published directly from MakeSourceTarball
       is_nightly(version) and 'success' in vr.get('MakeSourceTarball', {})
     ):

--- a/aws/hhvm1/lambdas/common.py
+++ b/aws/hhvm1/lambdas/common.py
@@ -18,6 +18,13 @@ class Config:
     'ForEachVersion': 'version',
     'ForEachPlatform': 'platform',
   }
+  macos_versions = {
+    # key: name as reported by build_statuses()
+    # value: version as reported by sw_vers -productVersion | cut -d . -f 1,2
+    # note: activity.BuildAndPublishMacOS depends on this having at most 2 items
+    'macos-high_sierra': '10.13',
+    'macos-mojave': '10.14',
+  }
 
 def is_nightly(version):
   return re.fullmatch(r'[0-9]{4}\.[0-9]{2}\.[0-9]{2}', version)
@@ -58,6 +65,9 @@ def env_for_version(version):
   env['S3_SOURCE'] = 's3://{S3_BUCKET}/{S3_PATH}'.format(**env)
   env['PACKAGING_BRANCH'] = branch(version)
   return env
+
+def format_env(env):
+  return '\n'.join([f'{var}="{value}"' for var, value in env.items()])
 
 @functools.lru_cache()
 def build_statuses(version):

--- a/aws/hhvm1/lambdas/prepare_activity.py
+++ b/aws/hhvm1/lambdas/prepare_activity.py
@@ -9,7 +9,7 @@ import random
 from time import sleep
 
 import activities
-from common import env_for_version, fake_ec2, skip_ec2
+from common import env_for_version, fake_ec2, format_env, skip_ec2
 
 def lambda_handler(event, context=None):
   activity_name = event['activity']
@@ -39,12 +39,12 @@ def lambda_handler(event, context=None):
     env['DISTRO'] = event['platform']
 
   env.update(env_for_version(version))
-  env.update(activity.env)
+  env.update(activity.task_env())
 
   return {
     'skip': False,
     'taskInput': {
       'name': task_name,
-      'env': '\n'.join([f'{var}="{value}"' for var, value in env.items()]),
+      'env': format_env(env),
     },
   }

--- a/aws/hhvm1/worker/run-test-workers.sh
+++ b/aws/hhvm1/worker/run-test-workers.sh
@@ -33,6 +33,7 @@ ACTIVITIES=(
   "arn:aws:states:us-west-2:223121549624:activity:hhvm-publish-binary-packages"
   "arn:aws:states:us-west-2:223121549624:activity:hhvm-publish-source-tarball"
   "arn:aws:states:us-west-2:223121549624:activity:hhvm-publish-docker-images"
+  "arn:aws:states:us-west-2:223121549624:activity:hhvm-build-and-publish-macos"
 )
 
 for ARN in "${ACTIVITIES[@]}"; do

--- a/aws/userdata/trigger-macos-builds.sh
+++ b/aws/userdata/trigger-macos-builds.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+# Import GitHub's public SSH key.
+mkdir -p ~/.ssh
+touch ~/.ssh/known_hosts
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# Decrypt and import private SSH key for pushing.
+eval $(ssh-agent -s)
+
+ENCRYPTED_KEY_PATH=$(mktemp)
+
+curl --retry 5 \
+  "https://raw.githubusercontent.com/hhvm/packaging/master/aws/homebrew-repo-push-key.kms-ciphertext" \
+  > "$ENCRYPTED_KEY_PATH"
+
+aws kms decrypt \
+  --region us-west-2 \
+  --ciphertext-blob "fileb://$ENCRYPTED_KEY_PATH" \
+  --query Plaintext --output text \
+  | base64 --decode \
+  | ssh-add -
+
+# Push a new commit to trigger the MacOS build.
+git clone git@github.com:hhvm/homebrew-hhvm.git
+cd homebrew-hhvm
+git config user.name "HHVM Homebrew Bot (AWS)"
+git config user.email opensource+hhvm-homebrew-bot@fb.com
+git checkout build-triggers
+
+TRIGGER_FILE="builds/$(date +%Y-%m-%d_%H-%M-%S)_$RANDOM.sh"
+
+echo "
+  VERSION='$VERSION'
+  PLATFORM='$PLATFORM'
+  SKIP_IF_DONE=1
+  TASK_TOKEN=$(printf %q "$TASK_TOKEN")
+" > "$TRIGGER_FILE"
+
+COMMIT_MESSAGE="[aws] build $VERSION"
+if [ -n "$PLATFORM" ]; then
+  COMMIT_MESSAGE="$COMMIT_MESSAGE on $PLATFORM"
+fi
+
+git add "$TRIGGER_FILE"
+git commit -m "$COMMIT_MESSAGE"
+git pull --rebase  # make race conditions less likely
+git push
+
+# Cleanup.
+cd ..
+rm -rf homebrew-hhvm
+ssh-add -D


### PR DESCRIPTION
This built yesterday's release and nightly.

Code that runs on Azure is in this homebrew-hhvm branch: https://github.com/hhvm/homebrew-hhvm/tree/build-triggers

I don't know why everything conveniently fails exactly when I need to test error handling but check out how the Azure build [failed and got automatically retried](https://dev.azure.com/hhvm-oss/hhvm-oss-builds/_build?definitionId=1).