### PR TITLE
convenient script for build status/output

### DIFF
--- a/bin/aws-build-status
+++ b/bin/aws-build-status
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+PREFIX="arn:aws:states:us-west-2:223121549624"
+SM="$PREFIX:stateMachine:one-state-machine-to-rule-them-all"
+EXEC="$PREFIX:execution:one-state-machine-to-rule-them-all"
+
+case "$1" in
+  "")
+    # no args: show everything (list + latest output)
+    SHOW_LIST=true
+    SHOW_OUTPUT=true
+    ;;
+  l|list|-l|--list)
+    # show list only
+    SHOW_LIST=true
+    SHOW_OUTPUT=false
+    ;;
+  *)
+    # execution name was specified, show only the relevant output
+    SHOW_LIST=false
+    SHOW_OUTPUT=true
+    ;;
+esac
+
+if $SHOW_LIST; then
+  aws stepfunctions list-executions \
+    --max-items 10 \
+    --output table \
+    --query "executions[*].{name:name,status:status}" \
+    --state-machine-arn "$SM"
+
+  echo
+  echo "Use '$0 <name>' to get output of a specific execution."
+fi
+
+if ! $SHOW_OUTPUT; then
+  exit 0
+fi
+
+NAME="$1"
+if [ -z "$NAME" ]; then
+  # missing name: use latest
+  NAME=$(
+    aws stepfunctions list-executions \
+      --max-items 1 \
+      --output text \
+      --query "executions[*].name" \
+      --state-machine-arn "$SM" \
+      | head -n 1
+  )
+fi
+
+JSON=$(aws stepfunctions describe-execution --execution-arn "$EXEC:$NAME")
+STATUS=$(echo "$JSON" | jq -r .status)
+
+echo
+echo "Execution '$NAME' $STATUS."
+echo
+
+if [ "$STATUS" == "SUCCEEDED" ]; then
+  echo "$JSON" | jq -r .output | jq .
+
+elif [ "$STATUS" == "FAILED" ]; then
+  EVENTS=$(
+    aws stepfunctions get-execution-history \
+      --reverse-order \
+      --max-items 30 \
+      --execution-arn "$EXEC:$NAME"
+  )
+
+  # dig out the error message
+  echo "$EVENTS" | jq -r '
+    .events[] |
+    select(.type == "ExecutionFailed") |
+    .executionFailedEventDetails.cause
+  ' | jq -r .errorMessage | sed 's/$/\n/'
+
+  # dig out the output (input to the final step)
+  FINAL_STEP="arn:aws:lambda:us-west-2:223121549624:function:hhvm1-check-for-failures"
+  echo "$EVENTS" | jq -r "
+    .events[].lambdaFunctionScheduledEventDetails |
+    select(.resource == \"$FINAL_STEP\") |
+    .input
+  " | jq .
+fi


### PR DESCRIPTION
Example runs:

```
$ bin/aws-build-status
--------------------------------------------------------------------------------------------
|                                      ListExecutions                                      |
+-----------------------------------------------------------------------------+------------+
|                                    name                                     |  status    |
+-----------------------------------------------------------------------------+------------+
|  4.32.0-jjergus-2019-11-18-09-41                                            |  SUCCEEDED |
|  6384d65c-e75c-0bfa-cf09-7722db64791d_498d26f9-db6f-868f-7d94-5b7e4b8095fe  |  SUCCEEDED |
|  ff503c2d-64f2-3330-fce9-5dbf640df4d5_ee03f01b-ef03-030d-8861-721836c2d23b  |  SUCCEEDED |
|  2019.11.16_debian-8--fredemmott-2019-11-16-10-08                           |  SUCCEEDED |
|  5ec79f5b-3a5f-7dd0-c0da-d18a1534c517_5c389c23-f147-adf7-e9b8-19bd254b2b55  |  FAILED    |
|  fde473ad-9bdb-29d7-126d-766969a8f4ec_9eafdcc7-a3e8-7320-b8d4-8a9700f496a1  |  FAILED    |
|  8b71d7be-8cb1-2571-f766-1386ea277e8d_737debc3-5158-e705-53a7-d6795e03f50e  |  SUCCEEDED |
|  eac84cd1-e484-a6dd-1d58-2b97043144b4_21ce6976-ffd3-9cd3-d67d-b891fa00bf8f  |  SUCCEEDED |
|  ecc66681-4aa7-d4f3-8881-12bff664c5e6_8f625b4e-8c99-1080-f7ea-89d393307a44  |  SUCCEEDED |
|  MakeBinaryPackage_3.-jjergus-2019-11-11-11-43                              |  ABORTED   |
+-----------------------------------------------------------------------------+------------+

Use 'bin/aws-build-status <name>' to get output of a specific execution.

Execution '4.32.0-jjergus-2019-11-18-09-41' SUCCEEDED.

{
  "ForEachVersion": {
    "4.32.0": {
      "MakeSourceTarball": {
        "success": {
          "ec2": "i-0391840f5f84478c3",
          "time_sec": "844"
        }
      },
      "ForEachPlatform": {
...
```

```
$ bin/aws-build-status 5ec79f5b-3a5f-7dd0-c0da-d18a1534c517_5c389c23-f147-adf7-e9b8-19bd254b2b55

Execution '5ec79f5b-3a5f-7dd0-c0da-d18a1534c517_5c389c23-f147-adf7-e9b8-19bd254b2b55' FAILED.

The following steps have failed:

MakeBinaryPackage 2019.11.16 debian-8-jessie {"ec2":"i-0ed0b56efbd277d09","time_sec":"1167"}

PublishBinaryPackages 2019.11.16 {"errorMessage": "cannot publish because there are unbuilt packages: debian-8-jessie", "errorType": "Exception", "stackTrace": ["  File \"/var/task/prepare_activity.py\", line 27, in lambda_handler\n    if not skip_ec2(event) and not fake_ec2(event) and not activity.should_run():\n", "  File \"/var/task/activities.py\", line 173, in should_run\n    for platform, status in common.build_statuses(self.version()).items()\n", "  File \"/var/task/activities.py\", line 156, in any_unpublished\n    ', '.join(p for p in statuses if statuses[p] == 'not_built')\n"]}


{
  "ForEachVersion": {
    "2019.11.16": {
      "MakeSourceTarball": {
        "success": {
          "ec2": "i-0dc366ee1cd1da9a3",
          "time_sec": "747"
        }
      },
      "ForEachPlatform": {
...
```