### PR TITLE
add python3 to build-depends

### DIFF
--- a/debian-8-jessie/debian/control
+++ b/debian-8-jessie/debian/control
@@ -58,6 +58,7 @@ Build-Depends:
   libxml2-dev,
   libxslt1-dev,
   libyaml-dev,
+  python3,
   rsync,
   tzdata,
   unzip,

--- a/debian-9-stretch/debian/control
+++ b/debian-9-stretch/debian/control
@@ -58,6 +58,7 @@ Build-Depends:
   libxml2-dev,
   libxslt1-dev,
   libyaml-dev,
+  python3,
   rsync,
   tzdata,
   unzip,

--- a/ubuntu-18.04-bionic/debian/control
+++ b/ubuntu-18.04-bionic/debian/control
@@ -58,6 +58,7 @@ Build-Depends:
   libxml2-dev,
   libxslt1-dev,
   libyaml-dev,
+  python3,
   rsync,
   tzdata,
   unzip,


### PR DESCRIPTION
I didn't see any errors on any of the supported systems (probably they all have a good enough version of python installed by default) but I guess it's better to declare it as an explicit dependency just in case?

I can update https://github.com/facebook/hhvm/pull/8665 to prefer python3 if available but if it builds successfully with any version of python maybe that's not necessary.