### PR TITLE
More involved vimrc for hhvm ondemands

### DIFF
--- a/aws/ondemand/facebook/hhvm/init-container.sh
+++ b/aws/ondemand/facebook/hhvm/init-container.sh
@@ -59,8 +59,15 @@ cat >> /root/.bash_logout <<ANALBUMCOVER
   echo
 ANALBUMCOVER
 
-touch /root/.vimrc
-echo "syntax on" >> /root/.vimrc
+cat >> /root/.vimrc <<ANALBUMCOVER
+syntax on
+set background=dark
+set tabstop=2
+set softtabstop=2
+set expandtab
+set backspace=indent,eol,start
+set mouse=a
+ANALBUMCOVER
 
 cat > /root/.gitignore_global <<ANALBUMCOVER
 debian


### PR DESCRIPTION
- `set background=dark` - no one uses white on black terminals, right?
- tabstop=2, softtabstop=2: FB uses 2-space tabs
- expandtabs: ... actually, we use spaces

My preference, but hopefully uncontenious
- make 'backspace' allow deletion of more things
- enable mouse support in all modes