### PR TITLE
bin/prune-source-tree

### DIFF
--- a/bin/make-source-tarball
+++ b/bin/make-source-tarball
@@ -69,13 +69,7 @@ fi
 git submodule update --init --recursive
 
 # Delete stuff we dont' need
-find . -name '.git' | xargs rm -rf
-# ~ 500mb here
-rm -rf third-party/fb-mysql/mysql-5.6/{rocksdb,xtrabackup,rqg,mysql-test}
-# ~ 250mb here
-rm -rf hphp/test/{slow,quick,zend,zend7}
-# ~ 200mb here
-rm -rf third-party/boost/boost/libs/*/{doc,test}
+"$ROOT/bin/prune-source-tree" .
 
 cd ..
 $TAR zcf "${OUT}/${PREFIX}-${VERSION}.tar.gz" "${PREFIX}-${VERSION}"

--- a/bin/prune-source-tree
+++ b/bin/prune-source-tree
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+if [ -z "$1" ] || [ ! -d "$1" ]; then
+  echo "Usage: $0 <hhvm dir>"
+  echo
+  echo "Removes files that are not needed in the source tarball (.git dirs, docs, tests),"
+  echo "freeing several GB of space (several hundred MB after compression)."
+  exit 1
+fi
+
+pushd "$1"
+
+find . -name .git -print0 | xargs -0 rm -rf
+# ~ 500mb here
+rm -rf third-party/fb-mysql/mysql-5.6/{rocksdb,xtrabackup,rqg,mysql-test}
+# ~ 250mb here
+rm -rf hphp/test/{slow,quick,zend,zend7}
+# ~ 200mb each here
+rm -rf third-party/boost/boost/libs/*/{doc,test}
+rm -rf third-party/fb-mysql/mysql-5.6/boost/libs/*/{doc,test}
+
+popd

--- a/bin/prune-source-tree
+++ b/bin/prune-source-tree
@@ -17,12 +17,11 @@ fi
 pushd "$1"
 
 find . -name .git -print0 | xargs -0 rm -rf
-# ~ 500mb here
-rm -rf third-party/fb-mysql/mysql-5.6/{rocksdb,xtrabackup,rqg,mysql-test}
+# ~ 1100mb here
+rm -rf third-party/fb-mysql/mysql-5.6/{boost,rocksdb,xtrabackup,rqg,mysql-test}
 # ~ 250mb here
 rm -rf hphp/test/{slow,quick,zend,zend7}
-# ~ 200mb each here
+# ~ 200mb here
 rm -rf third-party/boost/boost/libs/*/{doc,test}
-rm -rf third-party/fb-mysql/mysql-5.6/boost/libs/*/{doc,test}
 
 popd

--- a/bin/test-build-on-all-distros
+++ b/bin/test-build-on-all-distros
@@ -46,12 +46,7 @@ WORK_DIR="$(mktemp -dt hhvm.XXXXXXXX)"
   cp -r "$SOURCE_DIR" "$WORK_DIR/hhvm-$VERSION"
 )
 
-pushd "$WORK_DIR/hhvm-$VERSION" >/dev/null
-find . -name .git -print0 | xargs -0 rm -rf
-rm -rf third-party/fb-mysql/mysql-5.6/{rocksdb,xtrabackup,rqg,mysql-test}
-rm -rf hphp/test/{slow,quick,zend,zend7}
-rm -rf third-party/boost/boost/libs/*/{doc,test}
-popd >/dev/null
+"$(dirname "$0")/prune-source-tree" "$WORK_DIR/hhvm-$VERSION"
 
 pushd "$WORK_DIR" >/dev/null
 (


### PR DESCRIPTION
- extracts source tarball cleanup into a shared script
- adds 1 more set of dirs to clean up (`third-party/fb-mysql/mysql-5.6/boost/libs/*/{doc,test}`)

There are multiple redundant submodules in `third-party/fb-mysql` (boost, lz4, maybe others), I wonder if we can clean that up. But fb-mysql seems to have strong opinions about the exact boost version it needs, so it would probably make more sense if we used fb-mysql's boost in HHVM than vice versa. I'm not sure how linking works if we end up trying to statically link multiple different versions of the same library...