### PR TITLE
Remove duplicate `lib/` from install destinations

### DIFF
--- a/ubuntu-18.04-bionic/debian/hhvm-nightly-dev.install.in
+++ b/ubuntu-18.04-bionic/debian/hhvm-nightly-dev.install.in
@@ -1,4 +1,4 @@
 __PKGROOT__/bin/hhvm-gdb __PKGROOT__/bin
 __PKGROOT__/bin/hphpize __PKGROOT__/bin
 __PKGROOT__/include/hphp __PKGROOT__/include
-__PKGROOT__/lib __PKGROOT__/lib
+__PKGROOT__/lib __PKGROOT__/


### PR DESCRIPTION
refs #249

Packages currently have a `lib/lib` subpath in them; as `grep` shows
no `lib/lib` in this repo and other entries in this file do not have the
final component, I'm assuming this is correct. Will test before landing.
