### PR TITLE
drop support for MacOS 10.14 (Mojave)

### DIFF
--- a/aws/hhvm1/lambdas/common.py
+++ b/aws/hhvm1/lambdas/common.py
@@ -21,7 +21,6 @@ class Config:
   macos_versions = {
     # key: name as reported by build_statuses()
     # value: version as reported by sw_vers -productVersion | cut -d . -f 1,2
-    'macos-mojave': '10.14',
     'macos-catalina': '10.15',
   }
 

--- a/aws/lambdas/hhvm-get-build-status/index.js
+++ b/aws/lambdas/hhvm-get-build-status/index.js
@@ -29,7 +29,9 @@ async function get_distros(branch) {
 exports.handler = async (event) => {
   const {nightly, version, branch} = get_version_info(event);
 
-  const maj_min = version.split('.').slice(0, 2).join('.');
+  const maj = parseInt(version.split('.')[0]);
+  const min = parseInt(version.split('.')[1]);
+  const maj_min = maj+'.'+min;
   const macos_prefix = nightly
     ? 'hhvm-nightly-'+version
     : maj_min === '3.30'
@@ -37,13 +39,13 @@ exports.handler = async (event) => {
       : 'hhvm-'+maj_min+'-'+version;
   const src_prefix = nightly ? macos_prefix : ('hhvm-'+version);
   const paths = {
-    'macos-mojave':
-      'homebrew-bottles/'+macos_prefix+'.mojave.bottle.tar.gz',
+    'macos-catalina':
+      'homebrew-bottles/'+macos_prefix+'.catalina.bottle.tar.gz',
   };
-  //if (nightly && version >= '2020.02.04' || !nightly && maj_min >= '4.43') {
-    paths['macos-catalina'] =
-      'homebrew-bottles/'+macos_prefix+'.catalina.bottle.tar.gz';
-  //}
+  if (nightly && version < '2021.04.01' || !nightly && (maj < 4 || min < 104)) {
+    paths['macos-mojave'] =
+      'homebrew-bottles/'+macos_prefix+'.mojave.bottle.tar.gz';
+  }
 
   const scratch_paths = {};
   if (nightly) {


### PR DESCRIPTION
Needed for https://github.com/facebook/hhvm/pull/8813, because the latest Folly doesn't compile on MacOS 10.14.