### PR TITLE
retry shutdown in worker.sh

### DIFF
--- a/aws/hhvm1/worker/worker.sh
+++ b/aws/hhvm1/worker/worker.sh
@@ -181,5 +181,12 @@ while true; do
   echo "No more tasks for me, good bye."
   cleanup  # init script may declare this
   shutdown -h +1
-  exit 0
+
+  # Sometimes the scheduled shutdown doesn't happen for some reason. I'm not
+  # sure if retrying it will help, but it's probably worth a try. This one also
+  # uses "now" instead of "+1" in case the time offset is causing the problem.
+  while true; do
+    sleep 120
+    shutdown -h now
+  done
 done


### PR DESCRIPTION
For some reason the AWS EC2 instance sometimes doesn't shut down and just hangs there forever, even though the logs clearly show that it reached the shutdown command and ran it (I just had to manually terminate 6 instances that were created at different points over the last few weeks, it seems completely random).

I don't know what causes it, but maybe this simple hack will help?