### PR TITLE
Limit the Make concurrency to 8 threads

### DIFF
--- a/ubuntu-18.04-bionic/debian/rules
+++ b/ubuntu-18.04-bionic/debian/rules
@@ -13,7 +13,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	dh_auto_build -- -j1 hack hack_rust_ffi_bridge_targets
-	dh_auto_build --
+	dh_auto_build -- -j8
 
 override_dh_strip:
 	dh_strip --dbg-package=hhvm-nightly-dbg


### PR DESCRIPTION
According to the [build status](https://hhvm.com/api/build-status/2021.11.16), the nightly build continuously fails, while the build succeeded when manually retrying on a devserver.

This might be due to out of memory, and hopefully the issue could be fixed by limiting the concurrency in this PR.

