### PR TITLE
Add fix instructions to incorrect origin message.

### DIFF
--- a/bin/promote-nightly-to-release
+++ b/bin/promote-nightly-to-release
@@ -137,10 +137,6 @@ Tagging version:
 ----------------
 EOF
 
-if $DRY_RUN; then
-  exit 0
-fi
-
 if $FORCE; then
   FORCEABLE='[WARNING - FORCED]'
 else
@@ -162,6 +158,23 @@ if ! git diff --exit-code >/dev/null; then
   $FORCE || exit 1
 fi
 
+REQUIRED_GIT_ORIGIN="git@github.com:hhvm/packaging.git"
+GIT_ORIGIN="$(git remote get-url --push origin)"
+
+if [ "$GIT_ORIGIN" != "$REQUIRED_GIT_ORIGIN" ]; then
+  echo "${FORCEABLE} Git origin push URL is unsupported:"
+  echo "  - Current value: ${GIT_ORIGIN}"
+  echo "  - Required value: ${REQUIRED_GIT_ORIGIN}"
+  echo "  - Fix: git remote set-url --push origin ${REQUIRED_GIT_ORIGIN}"
+  $FORCE || exit 1
+fi
+
+if $DRY_RUN; then
+  echo "Dry run - exiting."
+  exit 0
+fi
+
+
 echo "Fetching any updates to packaging repo..."
 git fetch >/dev/null
 if ! git diff --exit-code origin/master..HEAD >/dev/null; then
@@ -177,12 +190,6 @@ if ! command -v "$SED" >/dev/null; then
     echo "Try: brew install gnu-sed"
   fi
   exit 1
-fi
-
-GIT_ORIGIN="$(git remote get-url origin)"
-if [ "$GIT_ORIGIN" != "git@github.com:hhvm/packaging.git" ]; then
-  echo "${FORCEABLE} Git origin must be set to git@github.com:hhvm/packaging.git (actual $GIT_ORIGIN)."
-  $FORCE || exit 1
 fi
 
 function statusline() {


### PR DESCRIPTION
- move stuff around so that `--dry-run` can be used to test this
- Use `--push` URLs so support pulling from https and pushing with ssh.
  This lets you pull/rebase etc without access to an SSH key, which is
  convenient if it's stored on a yubikey for example
- Provide fix instructions

Test Plan:

```
$ git remote set-url --push origin https://example.com
$ bin/promote-nightly-to-release 2021.11.18 4.136 --dry-run --force
----------------
--- Versions ---
----------------
Nightly build:
  2021.11.18
Previous version:
  4.135
Tagging version:
  4.136
----------------
[WARNING - FORCED] Run from master branch.
[WARNING - FORCED] Uncommitted changes.
[WARNING - FORCED] Git origin push URL is unsupported:
  - Current value: https://example.com
  - Required value: git@github.com:hhvm/packaging.git
  - Fix:
     git remote set-url --push origin git@github.com:hhvm/packaging.git
Dry run - exiting.
$ git remote set-url --push origin git@github.com:hhvm/packaging.git
$ bin/promote-nightly-to-release --dry-run 2021.11.18 4.136 --force
----------------
--- Versions ---
----------------
Nightly build:
  2021.11.18
Previous version:
  4.135
Tagging version:
  4.136
----------------
[WARNING - FORCED] Run from master branch.
[WARNING - FORCED] Uncommitted changes.
Dry run - exiting.
```
