### PR TITLE
Save build failure logs to S3

### DIFF
--- a/aws/hhvm1/worker/after-task/make-binary-package.sh
+++ b/aws/hhvm1/worker/after-task/make-binary-package.sh
@@ -11,10 +11,7 @@ if $SUCCESS; then
 else
   IMAGE_NAME=hhvm-failed-builds
   aws s3 cp /var/log/cloud-init-output.log "s3://hhvm-scratch/build-failure-${VERSION}-${DISTRO}-${EC2_INSTANCE_ID}.cloud-init-output.log"
-  # Use /dev/shm to increase chances of succeeding when the disk is full
-  DMESG=$(mktemp -p /dev/shm dmesg-log-XXXXXX)
-  dmesg > "$DMESG"
-  aws s3 cp "$DMESG" "s3://hhvm-scratch/build-failure-${VERSION}-${DISTRO}-${EC2_INSTANCE_ID}.dmesg.log"
+  aws s3 cp /var/log/kern.log "s3://hhvm-scratch/build-failure-${VERSION}-${DISTRO}-${EC2_INSTANCE_ID}.dmesg.log"
   rm "$DMESG"
 fi
 

--- a/aws/hhvm1/worker/after-task/make-binary-package.sh
+++ b/aws/hhvm1/worker/after-task/make-binary-package.sh
@@ -11,7 +11,8 @@ if $SUCCESS; then
 else
   IMAGE_NAME=hhvm-failed-builds
   aws s3 cp /var/log/cloud-init-output.log "s3://hhvm-scratch/build-failure-${VERSION}-${DISTRO}-${EC2_INSTANCE_ID}.cloud-init-output.log"
-  DMESG=$(mktemp)
+  # Use /dev/shm to increase chances of succeeding when the disk is full
+  DMESG=$(mktemp -p /dev/shm dmesg-log-XXXXXX)
   dmesg > "$DMESG"
   aws s3 cp "$DMESG" "s3://hhvm-scratch/build-failure-${VERSION}-${DISTRO}-${EC2_INSTANCE_ID}.dmesg.log"
   rm "$DMESG"

--- a/aws/hhvm1/worker/after-task/make-binary-package.sh
+++ b/aws/hhvm1/worker/after-task/make-binary-package.sh
@@ -6,13 +6,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -ex
-
 if $SUCCESS; then
   IMAGE_NAME=hhvm-successful-builds
 else
   IMAGE_NAME=hhvm-failed-builds
+  aws s3 cp /var/log/cloud-init-output.log "s3://hhvm-scratch/build-failure-${VERSION}-${DISTRO}-${EC2_INSTANCE_ID}.cloud-init-output.log"
+  DMESG=$(mktemp)
+  dmesg > "$DMESG"
+  aws s3 cp "$DMESG" "s3://hhvm-scratch/build-failure-${VERSION}-${DISTRO}-${EC2_INSTANCE_ID}.dmesg.log"
+  rm "$DMESG"
 fi
+
+set -ex
 
 # On modern systems, this should just be:
 #   $(aws ecr get-login --no-include-email --region us-west-2)


### PR DESCRIPTION
Using the existing bucket for now; will make another one with custom
retention policies if we can't fix the flakiness quickly.

Test Plan:

Shellcheck.

Land. Tomorrow:
- check for corresponding success/failure docker images
- check for log files in s3 if there are failures
- revert if there's problems, so we get good signal over the holidays
