### PR TITLE
Run MakeBinaryPackage on r6i.4xlarge EC2 instances instead of m5.4xlarge

### DIFF
--- a/aws/hhvm1/lambdas/activities.py
+++ b/aws/hhvm1/lambdas/activities.py
@@ -154,7 +154,7 @@ class MakeBinaryPackage(Activity):
   def ec2_params(self):
     params = super().ec2_params()
     params.update({
-      'InstanceType': 'm5.4xlarge',  # 16 cores, 64GB RAM
+      'InstanceType': 'r6i.4xlarge',  # 16 cores, 128GB RAM
       'BlockDeviceMappings': [{
         'DeviceName': '/dev/sda1',
         'Ebs': {

--- a/aws/hhvm1/lambdas/test.py
+++ b/aws/hhvm1/lambdas/test.py
@@ -162,7 +162,7 @@ class Test(unittest.TestCase):
       {'version': '4.26.1', 'platform': 'ubuntu-18.04-bionic'}
     ).ec2_params()
     self.assertEqual(ec2_params['MinCount'], 1)
-    self.assertEqual(ec2_params['InstanceType'], 'm5.4xlarge')
+    self.assertEqual(ec2_params['InstanceType'], 'r6i.4xlarge')
     self.assertEqual(
       ec2_params['BlockDeviceMappings'][0]['DeviceName'],
       '/dev/sda1',


### PR DESCRIPTION
According to https://aws.amazon.com/ec2/instance-types/, `r6i.4xlarge` doubles the memory in comparison to `m5.4xlarge`. Hopefully it would reduce the out of memory errors.