### PR TITLE
Revert "Limit the Make concurrency to 8 threads"

### DIFF
--- a/ubuntu-18.04-bionic/debian/rules
+++ b/ubuntu-18.04-bionic/debian/rules
@@ -13,7 +13,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	dh_auto_build -- -j1 hack hack_rust_ffi_bridge_targets
-	dh_auto_build -- -j8
+	dh_auto_build --
 
 override_dh_strip:
 	dh_strip --dbg-package=hhvm-nightly-dbg


### PR DESCRIPTION
Reverts hhvm/packaging#260

Since we can allocate more memory and less CPU for better CPU utilization in #272