### PR TITLE
Increase the build timeout

### DIFF
--- a/aws/hhvm1/state-machine/generate.hack
+++ b/aws/hhvm1/state-machine/generate.hack
@@ -162,10 +162,10 @@ abstract final class Config {
   const dict<A, int> TIMEOUT_SEC = dict[
     A::MakeSourceTarball => 30 * 60,
     A::MakeBinaryPackage => 4 * 60 * 60,
-    A::PublishBinaryPackages => 180 * 60,
-    A::PublishDockerImages => 180 * 60,
+    A::PublishBinaryPackages => 240 * 60,
+    A::PublishDockerImages => 240 * 60,
     A::PublishSourceTarball => 30 * 60,
-    A::BuildAndPublishMacOS => 180 * 60,
+    A::BuildAndPublishMacOS => 240 * 60,
   ];
 
   /**


### PR DESCRIPTION
It takes 2h 56m 26s to complete [the build for 2022.02.02](https://dev.azure.com/hhvm-oss/hhvm-oss-builds/_build/results?buildId=1700&view=results), which is close to the 3 hour limit. Also there are previous builds failed due to time out.

This PR increases the timeout to reduce timeout errors.