### PR TITLE
Don't escape `${workspaceFolder}`

### DIFF
--- a/aws/ondemand/facebook/hhvm/init-container.sh
+++ b/aws/ondemand/facebook/hhvm/init-container.sh
@@ -33,7 +33,7 @@ fi
 BUILD_DIR="${DIRS[0]}"
 
 mkdir -p /root/.vscode-server/data/Machine/
-cat > /root/.vscode-server/data/Machine/settings.json <<ANALBUMCOVER
+cat > /root/.vscode-server/data/Machine/settings.json <<'ANALBUMCOVER'
 {
   "cmake.configureArgs": [
     "-Wno-dev",


### PR DESCRIPTION
#279 did not work as expected because `${workspaceFolder}` was considered as a shell environment variable, while it should be a VS Code predefined variable.

This PR instead use single quoted heredoc to prevent `${workspaceFolder}` from being expanded by the shell.