### PR TITLE
Use bash pattern mathing instead of grep for macOS compatibility

### DIFF
--- a/bin/test-build-on-all-distros
+++ b/bin/test-build-on-all-distros
@@ -41,18 +41,23 @@ fi
 
 WORK_DIR="$(mktemp -dt hhvm.XXXXXXXX)"
 
+if command -v gtar
+then
+  TAR=gtar # the executable of GNU Tar in Homebrew 
+else
+  TAR=tar
+fi
 (
   set -x
   cd "$SOURCE_DIR"
-  git checkout-index -a -f --prefix="$WORK_DIR/hhvm-$VERSION/"
+  git ls-files --recurse-submodules |
+  grep --invert-match -E -e '^"?hphp/test/(slow|quick|zend|zend7)/' |
+  "$TAR" caf "$WORK_DIR/hhvm-$VERSION.tar.gz" --xform "s,^,hhvm-$VERSION/,rSH" -T-
 )
-
-"$(dirname "$0")/prune-source-tree" "$WORK_DIR/hhvm-$VERSION"
 
 pushd "$WORK_DIR" >/dev/null
 (
   set -x
-  tar czf "hhvm-$VERSION.tar.gz" "hhvm-$VERSION"
   aws s3 cp "hhvm-$VERSION.tar.gz" s3://hhvm-scratch/
 )
 popd >/dev/null

--- a/bin/test-build-on-all-distros
+++ b/bin/test-build-on-all-distros
@@ -17,12 +17,22 @@ fi
 
 SOURCE_DIR="$1"
 shift
-
-pushd "$(dirname "$0")" >/dev/null
-MINOR=$(git branch -r | grep -Po '(?<=origin/HHVM-4.)[0-9]+' | sort -rn | head -1)
-popd >/dev/null
-if [ -z "$MINOR" ]; then
-  echo "Failed to get the latest packaging branch name."
+BRANCH=$(cd "$SOURCE_DIR" && git branch --show-current)
+if [[ "$BRANCH" =~ HHVM-4.([0-9]+) ]]
+then
+  MINOR="${BASH_REMATCH[1]}"
+else
+  for BRANCH in $(cd "$(dirname "$0")" && git branch -r --sort=-refname)
+  do
+    if [[ "$BRANCH" =~ HHVM-4.([0-9]+) && (-z "$MINOR" || "${BASH_REMATCH[1]}" -gt "$MINOR") ]]
+    then
+      MINOR="${BASH_REMATCH[1]}"
+    fi
+  done
+fi
+if [[ -z "$MINOR" ]]
+then
+  echo "Failed to get the latest packaging branch name." >&2
   exit 1
 fi
 


### PR DESCRIPTION
`/usr/bin/grep` on macOS does not support PCRE.

This PR also try to detect the version number from the current branch of the HHVM work tree, and fallback to the latest version only if the current branch is not a release branch.