### PR TITLE
Make promote-nightly-to-release idempotent

### DIFF
--- a/bin/promote-nightly-to-release
+++ b/bin/promote-nightly-to-release
@@ -202,11 +202,13 @@ function statusline() {
 }
 
 statusline "Creating packaging branch..."
-git checkout -b "HHVM-${VERSION}"
+git checkout -B "HHVM-${VERSION}"
 statusline "Marking support for new DISTRO apt repo.."
 echo "DISTRO-${VERSION}" >> DEBIAN_REPOSITORIES
 git commit DEBIAN_REPOSITORIES -m "Adding DISTRO-${VERSION} apt repositories"
 statusline "Pushing packaging branch..."
+git rebase master
+git pull --rebase origin "HHVM-${VERSION}"
 git push -u origin "HEAD:HHVM-${VERSION}"
 
 SCRATCHDIR="$(mktemp -dt hhvm.XXXXXXXX)"


### PR DESCRIPTION
Recently I removed `user.email` setting from my `~/.gitconfig`. As a result, when I ran `bin/promote-nightly-to-release`, it partially failed because it cannot commit to the `hhvm/hhvm-docker` repository. What is worse is that I could not rerun the script even when I added `user.email` back to `~/.gitconfig`, because it had created and pushed `HHVM-4.155` branch to this repository.

This PR lets the changes to this repository be idempotent, allowing me to rerun `promote-nightly-to-release` after a partial failure.