### PR TITLE
Merge internal 'making a patched HHVM 4.x.0 release' docs

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -7,8 +7,38 @@ Prerequisites:
   deal with issues)
 - access to HHVM FB page and Twitter accounts
 
-Creating a new .0 release
-==========================
+Overview of the repositories
+============================
+
+* fbcode: the source of truth for HHVM and Hack
+* https://github.com/facebook/hhvm - the public repository for HHVM and Hack. The master is automatically synced from fbcode by fbshipit
+
+* https://github.com/hhvm/hhvm-staging - a private fork of facebook/hhvm. This is the source of truth for tags and release branches. This allows us to prepare security updates in private in a repository accessible by AWS and Azure
+* https://github.com/hhvm/hhvm.com - public repository containing the hhvm.com (http://hhvm.com/) website and all blog posts
+* https://github.com/hhvm/packaging - public repository containing the overall public CI infrastructure, and the public linux build configurations/scripts
+* https://github.com/hhvm/homebrew-hhvm - public repository containing MacOS-specific public CI infrastructure; used by hhvm/packaging. This is a separate repository as homebrew dictates the repository name and structure.
+* https://github.com/hhvm/hhvm-docker - public repository containing the templates for our docker (container) images. This could be merged. It is a separate repository as it is self-contained and comparatively straightforward, but there is no need for it to be.
+
+**Security releases**: nothing should be done in any public repository - and no build steps should be ran that operate in/write to public repositories - until the planned disclosure date.
+
+Version numbers
+===============
+
+In the master branch, hphp/runtime/version.h always sets version to something like 4.x.0-dev - the “-dev” is always present, and is desired in manual and nightly builds. 4.x is the next release, not the latest. For example, if we have just released 4.155.0, version.h in master should be 4.156.0-dev
+
+
+* x can be incremented by manually editing the file (for master, this should be in fbcode, for releases, directly in the branches on GitHub), or, for master, by running `hphp/facebook/update_version_header.sh`
+    * if done manually or by the script in fbcode, a diff must be created and reviewed manually, like any other fbcode diff
+    * this should be done soon after the .0 release is tagged, both when following this procedure, and for regular .0 releases so that e.g . when 4.155.0 is tagged, the next nightly build is 4.156.0-dev, not 4.155.0-dev
+* CodemodConfigUpdateHHVMVersionHeader creates a diff once a week to update the version header, removing the need for this manual work. If there are test failures, a Meta employee must take ownership of the diff in order to land it.
+* Codemods are usually disabled during code freezes; when this is the case, the version number must be updated manually, or via the script.
+* The "-dev" needs to be removed from version.h in the release branch
+* nightly builds have a distinct YYYY.MM.DD package version number (e.g. .deb and homebrew), but this is not part of version.h or the included executables; hhvm --version will report the 4.x.0-dev string, no YYYY.MM.DD
+    * nightly-YYYY.MM.DD tags are automatically created and pushed to both facebook/hhvm and hhvm/staging, which makes it easy to identify the specific github commit used for a nightly build
+
+
+Creating a regular, unpatched .0 release
+========================================
 
 Releases are generally on Mondays, from Sunday's nightly builds.
 
@@ -74,73 +104,48 @@ Creating a new .z release
 1. The AWS step functions are now running; proceed with release notes and MacOS
    builds as for `.0` releases; do not update `version.h` in master.
 
-Building A MacOS Release On Azure
-=================================
+What `bin/promote-nightly-to-release YYYY.MM.DD 4.123` does
+===========================================================
 
-This lets us build many in parallel, instead of restricting us to our
-permanent worker machines.
+1. It creates and pushes an HHVM-4.123 branch of the hhvm/packaging repository; this is so that if we create 4.123.99 in a year, we have a reproducible build - e.g. the same debian build scripts as we used for 4.123.0
+2. It clones the facebook/hhvm repository
+3. It creates an HHVM-4.123 branch from the nightly-YYYY.MM.DD tag
+4. It runs bin/hhvm-tag-and-push 4.123.0
+    1. It removes the -dev from version.h
+    2. This is committed to the new branch as “Releasing 4.123.0” and tagged as HHVM-4.123.0
+    3. It changes the .0 and to version.h to .1 and re-adds "-dev"; This is so that if a build is made from this branch before the next release, it is clear that it is not the release build and may have different contents
+    4. This is committed to the new branch as “Targetting 4.123.1”
+    5. The branch and tag are pushed *to the private hhvm/staging repository* - they are not pushed to the public repository
 
-Initial Setup
--------------
 
-1. [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-2. `az login --allow-no-subscriptions`
-3. Add the 'devops' extension to get CLI access to Azure pipelines:
-   `az extension add --name azure-devops`
-4. Configure the Azure Devops extension to use the correct organization and project:
-    `az devops configure --defaults organization=https://dev.azure.com/hhvm-oss/ project=hhvm-oss-builds` - alternatively, add `--organization` and
-    `--project` options to all following commands
+5. It clones the hhvm/hhvm-docker repository
+6. It checks out the HHVM-4.$PREVIOUS_VERSION (e.g. HHVM-4.122) branch
+7. it removes latest from the EXTRA_TAGS file of the branch and commits it (docker ‘tags’ are essentially package version numbers/version aliases)
+8. It creates a new HHVM-4.123 branch
+9. it adds latest and 4.123-latest to the EXTRA_TAGS file; this makes it so that once built, HHVM-4.123 will be installed instead of HHVM-4.122 by docker install hhvm/hhvm - hhvm/hhvm:4.123-latest and hhvm:4.123.0 will also be created
+10. it commits this, and pushes both branches
+11. it runs bin/build-on-aws 4.123.0 - *this will build _and publish_ the release, source and binaries.* We generally expect that security updates will not be .0 releases.
 
-General Use
------------
+What `bin/build-on-aws` does
+============================
 
-Builds are triggered automatically from the AWS step function, so the commands
-below should only be needed in case of issues.
+This builds and publishes a release (or multiple releases) for all our supported platforms; it triggers an AWS Step Function (state-machine-as-a-service) to orchestrate the build. The step function will also trigger the MacOS builds on Azure
 
-Starting a job:
+You can also choose to run just specific steps - for example, if only docker failed, you can pass PublishDockerImages to run just that step. Run build-on-aws with --help or with no arguments for more details.
 
-```
-$ az pipelines build queue --variables hhvm.version=4.15.1 --definition-name hhvm-oss-builds-CI -o table
-```
+It is possible to prepare the Linux release builds without publishing them, e.g. for security fixes; specify the MakeSourceTarball and MakeBinaryPackage steps. MacOS currently can not be built without publishing.
 
-Listing jobs:
+Creating a patched `.0` release
+===============================
 
-```
-$ az pipelines build list --top 20 -o table
-ID    Number    Status      Result    Definition ID    Definition Name     Source Branch    Queued Time                 Reason
-----  --------  ----------  --------  ---------------  ------------------  ---------------  --------------------------  --------
-12    12        inProgress            1                hhvm-oss-builds-CI  master           2019-08-09 10:03:13.818939  manual
-11    11        completed   failed    1                hhvm-oss-builds-CI  master           2019-08-09 09:52:02.412387  manual
-10    10        completed   failed    1                hhvm-oss-builds-CI  master           2019-08-09 09:21:10.523309  manual
-9     9         completed   failed    1                hhvm-oss-builds-CI  master           2019-08-09 09:08:00.526379  manual
-5     5         completed   failed    1                hhvm-oss-builds-CI  master           2019-08-08 15:34:21.857854  manual
-8     8         completed   canceled  1                hhvm-oss-builds-CI  master           2019-08-08 15:43:00.310012  manual
-7     7         completed   canceled  1                hhvm-oss-builds-CI  master           2019-08-08 15:42:10.073800  manual
-6     6         completed   canceled  1                hhvm-oss-builds-CI  master           2019-08-08 15:41:19.357546  manual
-4     4         completed   failed    1                hhvm-oss-builds-CI  master           2019-08-08 15:31:09.347933  manual
-3     3         completed   failed    1                hhvm-oss-builds-CI  master           2019-08-08 15:19:30.592465  manual
-2     2         completed   failed    1                hhvm-oss-builds-CI  master           2019-08-08 15:10:51.677154  manual
-1     1         completed   failed    1                hhvm-oss-builds-CI  master           2019-08-08 15:07:30.406701  manual
-```
+This should be done rarely; we should usually create x.y.0 directly from the previous nightly, and we should aim to have all patches in master; one case for a patched .0 is when you want to create a new release with a security patch that has not yet hit GitHub master. Waiting a day is often a better choice, but if it’s late in the week, that may in effect mean skipping the release.
 
-For status of just one job:
 
-```
-$ az pipelines build show --id 12 -o table
-ID    Number    Status      Result    Definition ID    Definition Name     Source Branch    Queued Time                 Reason
-----  --------  ----------  --------  ---------------  ------------------  ---------------  --------------------------  --------
-12    12        inProgress            1                hhvm-oss-builds-CI  master           2019-08-09 10:03:13.818939  manual
-```
+`bin/promote-nightly-to-release YYYY.MM.DD 4.123` does many things, some of which are undesired for this case; in particular, we need to create the branch and tag by hand. The flow here looks like:
 
-Use the [Azure web interface](https://dev.azure.com/hhvm-oss/hhvm-oss-builds/_build?definitionId=1) to see detailed
-build status, including stdout/stderr.
-
-# Manual Fixups of Formula
-
-If a bottle is built, but the recipe update fails (e.g. git issues):
-
-- download with s3 or wget, e.g.
-  `aws s3 cp s3://hhvm-downloads/homebrew-bottles/hhvm@3.30-lts-3.30.8_1.high_sierra.bottle.tar.gz ./` , or
-  `wget https://dl.hhvm.com/homebrew-bottles/hhvm@3.30-lts-3.30.8_1.high_sierra.bottle.tar.gz'
-- generate sha, e.g. `openssl dgst -sha256 hhvm@3.30*sierra*`
-- manually add the sha to the bottle section
+1. Clone the facebook/hhvm repository, or use an existing checkout
+2. Create the release branch: git checkout -b HHVM-4.123 nightly-YYYY.MM.DD
+3. Apply and commit changes, e.g. with git cherry-pick, patch -p1 ; git commit etc
+4. Test changes
+5. run bin/hhvm-tag-and-push 4.123.0
+6. run bin/promote-nightly-to-release existing-tag 4.123 - this is literally the string ‘existing-tag’, not a placeholder/variable - as this is a .0 release, we still need the automated changes to the hhvm/packaging and hhvm/docker repositories


### PR DESCRIPTION
These give a lot more context that is generally useful, but especially
for understanding the intent and changes required when making a
non-standard release.
