### PR TITLE
Revert "Make a shallow clone in make-source-tarball"

### DIFF
--- a/bin/make-source-tarball
+++ b/bin/make-source-tarball
@@ -46,8 +46,9 @@ else
   HEAD=HHVM-${VERSION}
 fi
 
-git clone --depth 1 --branch "$HEAD" ${REPO} "${PREFIX}-${VERSION}"
+git clone ${REPO} "${PREFIX}-${VERSION}"
 cd "${PREFIX}-$VERSION"
+git checkout "$HEAD"
 if "${IS_AWS:-false}" && $IS_NIGHTLY; then
   TAG="nightly-${VERSION}"
   # Tag may already exist from previous failed runs.
@@ -67,7 +68,7 @@ if "${IS_AWS:-false}" && $IS_NIGHTLY; then
     git push git@github.com:facebook/hhvm.git "${TAG}"
   fi
 fi
-git submodule update --init --recursive --depth 1
+git submodule update --init --recursive
 
 # Delete stuff we dont' need
 "$ROOT/bin/prune-source-tree" .


### PR DESCRIPTION
Reverts hhvm/packaging#297
We stopped getting successful nightly builds due to failures in the MakeSourceTarball step the night after this landed. Trying to revert this to see if this is the cause.