### PR TITLE
Don't build hhbc_ast_cbindgen in parallel

### DIFF
--- a/ubuntu-18.04-bionic/debian/rules
+++ b/ubuntu-18.04-bionic/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_configure:
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 override_dh_auto_build:
-	dh_auto_build -- -j1 hack hack_rust_ffi_bridge_targets
+	dh_auto_build -- -j1 hack hack_rust_ffi_bridge_targets hhbc_ast_cbindgen
 	dh_auto_build -- -j8
 
 override_dh_strip:


### PR DESCRIPTION
Recently the build pipeline on AWS is flaky. The error logs seem to be related with concurrent executions of `invoke_cargo.sh` when building the `hhbc_ast_cbindgen` target.

This PR tries to mitigate the flakiness by not building `hhbc_ast_cbindgen` in parallel.