### PR TITLE
Don't build hack_dune in parallel

### DIFF
--- a/ubuntu-18.04-bionic/debian/rules
+++ b/ubuntu-18.04-bionic/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_configure:
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 override_dh_auto_build:
-	dh_auto_build -- -j1 hack hack_rust_ffi_bridge_targets hhbc_ast_cbindgen
+	dh_auto_build -- -j1 hack hack_rust_ffi_bridge_targets hhbc_ast_cbindgen hack_dune
 	dh_auto_build -- -j8
 
 override_dh_strip:


### PR DESCRIPTION
Similar to #321, `hack_dune` would trigger `invoke_cargo.sh`, and some flaky builds happen when building `hack_dune`. This PR tries to mitigate the flakiness by not building `hack_dune` in parallel.

